### PR TITLE
add commonjs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.idea

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./build/lub-tmdb');
+module.exports = 'lub-tmdb-api';

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "AngularJS Tmdb API",
   "version": "0.3.0",
   "homepage": "https://github.com/gnalFF/lub-tmbd",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/gnalFF/lub-tmbd.git"


### PR DESCRIPTION
according to angularjs guidelines...

after merging, the new release should be published to the npm registry to make use of the commonjs module in browserify and webpack projects
